### PR TITLE
Fix/sudachipy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Version 1.0.1](https://github.com/dataiku/dss-plugin-nlp-visualization/releases/tag/v1.0.1) - Bugfix release - 2022-07
+- ✨ Fix sudachipy version not being compatible with Python 3.6 anymore
+
 ## [Version 1.0.0](https://github.com/dataiku/dss-plugin-nlp-visualization/releases/tag/v1.0.0) - Initial release - 2021-10
 - ☁  Visualize text data using word clouds...
 - 🌎 🌍 🌏   ... in 59 languages!

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -12,3 +12,5 @@ wordcloud==1.8.0
 fonttools==4.14.0
 pathvalidate==2.3.0
 fastcore==1.3.19
+sudachipy==0.6.0; python_version == '3.6'
+

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "nlp-visualization",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "meta": {
         "label": "Text Visualization",
         "category": "Natural Language Processing",


### PR DESCRIPTION
There is no wheel available anymore for Py3 & sudachi py >0.6, hence requiring Rust to install. We remove this requirement by pinning a version.