### PR TITLE
Update wordcloud version to prevent issue with pillow>10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Version 1.1.1](https://github.com/dataiku/dss-plugin-nlp-visualization/releases/tag/v1.1.1) - Emhancement release - 2024-06
-- 🐍 Pin pillow version to prevent issue when running word cloud recipe
+- 🐍 Update required wordcloud version to prevent issue with pillow when running word cloud recipe
 
 ## [Version 1.1.0](https://github.com/dataiku/dss-plugin-nlp-visualization/releases/tag/v1.1.0) - Emhancement release - 2023-05
 - 🐍 Added support for python versions 3.8, 3.9 and 3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Version 1.1.1](https://github.com/dataiku/dss-plugin-nlp-visualization/releases/tag/v1.1.1) - Emhancement release - 2024-06
+- 🐍 Pin pillow version to prevent issue when running word cloud recipe
+
 ## [Version 1.1.0](https://github.com/dataiku/dss-plugin-nlp-visualization/releases/tag/v1.1.0) - Emhancement release - 2023-05
 - 🐍 Added support for python versions 3.8, 3.9 and 3.10
 

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -9,10 +9,9 @@ spacy[lookups,ja,th]==3.5.2; python_version >= '3.9'
 emoji==1.2.0
 tqdm==4.60.0
 matplotlib==3.3.1
-wordcloud==1.8.0; python_version < '3.9'
-wordcloud==1.8.2.2; python_version >= '3.9'
+wordcloud==1.8.0; python_version <= '3.6'
+wordcloud==1.9.3; python_version > '3.6'
 fonttools==4.14.0
 pathvalidate==2.3.0
 fastcore==1.3.19
 sudachipy==0.6.0; python_version == '3.6'
-pillow<=9.5.0

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -9,8 +9,8 @@ spacy[lookups,ja,th]==3.5.2; python_version >= '3.9'
 emoji==1.2.0
 tqdm==4.60.0
 matplotlib==3.3.1
-wordcloud==1.8.0; python_version <= '3.6'
-wordcloud==1.9.3; python_version > '3.6'
+wordcloud==1.8.0; python_version < '3.9'
+wordcloud==1.9.3; python_version >= '3.9'
 fonttools==4.14.0
 pathvalidate==2.3.0
 fastcore==1.3.19

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -15,3 +15,4 @@ fonttools==4.14.0
 pathvalidate==2.3.0
 fastcore==1.3.19
 sudachipy==0.6.0; python_version == '3.6'
+pillow<=9.5.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "nlp-visualization",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "meta": {
         "label": "Text Visualization",
         "category": "Natural Language Processing",


### PR DESCRIPTION
This fixes the following issue on pillow 10.3.0

Also, bumps plugin version to 1.1.1

```
Job failed: Error in Python process: At line 41: <class 'AttributeError'>: 'ImageDraw' object has no attribute 'textsize'
```

[sc-190692]