### PR TITLE
Pin sudachipy for python 3.7 and 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## [Version 1.1.1](https://github.com/dataiku/dss-plugin-nlp-visualization/releases/tag/v1.1.1) - Emhancement release - 2024-06
+## [Version 1.1.2](https://github.com/dataiku/dss-plugin-nlp-visualization/releases/tag/v1.1.2) - Bugfix release - 2025-01
+- 🐍 Update required sudachipy version to maintain compatibility with python 3.7 and 3.8
+
+## [Version 1.1.1](https://github.com/dataiku/dss-plugin-nlp-visualization/releases/tag/v1.1.1) - Bugfix release - 2024-06
 - 🐍 Update required wordcloud version to prevent issue with pillow when running word cloud recipe
 
 ## [Version 1.1.0](https://github.com/dataiku/dss-plugin-nlp-visualization/releases/tag/v1.1.0) - Emhancement release - 2023-05

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -15,3 +15,4 @@ fonttools==4.14.0
 pathvalidate==2.3.0
 fastcore==1.3.19
 sudachipy==0.6.0; python_version == '3.6'
+sudachipy<0.6.10; python_version >= '3.7' and python_version < '3.9'

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -15,4 +15,5 @@ fonttools==4.14.0
 pathvalidate==2.3.0
 fastcore==1.3.19
 sudachipy==0.6.0; python_version == '3.6'
-sudachipy<0.6.10; python_version >= '3.7' and python_version < '3.9'
+sudachipy<0.6.10; python_version >= '3.7' and python_version < '3.9' and platform_system != "Darwin"
+sudachipy<0.6.9; python_version >= '3.7' and python_version < '3.9' and platform_system == "Darwin"

--- a/plugin.json
+++ b/plugin.json
@@ -1,11 +1,11 @@
 {
     "id": "nlp-visualization",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "meta": {
         "label": "Text Visualization",
         "category": "Natural Language Processing",
         "description": "Visualize text as word clouds in 59 languages",
-        "author": "Dataiku (Alex LANDEAU, Alex COMBESSIE)",
+        "author": "Dataiku (CaraML)",
         "icon": "icon-quote-left",
         "tags": [
             "NLP"


### PR DESCRIPTION
Sudachipy released on the 10th of january 2025 version 0.6.10, with no wheels for python3.8 and before : 

https://pypi.org/project/SudachiPy/0.6.10/#files